### PR TITLE
skip openvis content blocks w/o speaker info

### DIFF
--- a/lib/fetchopenvis.js
+++ b/lib/fetchopenvis.js
@@ -36,6 +36,9 @@ FetchOpenVis.prototype.parseSchedule = function(html) {
   $('.speaker').each(function(i, el) {
     var $el = $(el);
 
+    // skip cells without speaker info
+    if ($el.find('.speaker-talk').length === 0) { return; }
+
     // create data structure
     this.results.push({
       speaker: $el.find('.speaker-name').text(),


### PR DESCRIPTION
### What changed?
- Added a condition to skip content blocks without speaker information.
